### PR TITLE
Center button text

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -18,6 +18,7 @@
   font-weight: vars.$buttons-font-weight;
   letter-spacing: vars.$buttons-letter-spacing;
   text-transform: vars.$buttons-text-transform;
+  text-align: center;
 
   // sizing
   padding: vars.$buttons-padding;


### PR DESCRIPTION
This pull request includes a small change to the `src/components/button/button.scss` file. The change centers the text within buttons by adding a `text-align: center;` property.

* [`src/components/button/button.scss`](diffhunk://#diff-80c708f46f5ec49cbd3566c30ea3ab15523be503141c6c42713918a32febe1edR21): Added `text-align: center;` to center the text within buttons.