### PR TITLE
Add new Modal property `dismissable` that prevents 'esc' btn when false (true by default)

### DIFF
--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -25,8 +25,13 @@
   transition: opacity vars.$transition-duration-and-function;
 
   &::backdrop {
-    cursor: pointer;
     transition: background-color vars.$transition-duration-and-function, backdrop-filter vars.$transition-duration-and-function;
+  }
+
+  &.ls-dialog-dismissable {
+    &::backdrop {
+      cursor: pointer;
+    }
   }
 
   // base style

--- a/src/components/modal/modal.stories.tsx
+++ b/src/components/modal/modal.stories.tsx
@@ -5,70 +5,116 @@ import { Button } from "../button";
 import { P } from "../typography";
 import { Modal } from "./modal";
 
+const textMiniModal =
+	"Laudantium nihil dolorem deleniti quae eos. Et ut sequi corporis. Alias voluptatem laboriosam omnis sit ratione mollitia. Minus quis magnam a cupiditate et. Qui voluptatibus ea nostrum repudiandae quidem molestias. Et velit saepe vero aliquid id doloremque. Officia animi ut natus. Sit quis neque esse ut magnam sit. Iure aspernatur quasi voluptate exercitationem. Velit et provident nobis earum eligendi voluptatem.";
+const textBigModal =
+	"Laudantium nihil dolorem deleniti quae eos. Et ut sequi corporis. Alias voluptatem laboriosam omnis sit ratione mollitia. Minus quis magnam a cupiditate et. Qui voluptatibus ea nostrum repudiandae quidem molestias. Et velit saepe vero aliquid id doloremque. Officia animi ut natus. Sit quis neque esse ut magnam sit. Iure aspernatur quasi voluptate exercitationem. Velit et provident nobis earum eligendi voluptatem. Et reiciendis laudantium et nesciunt recusandae et sit illum. Pariatur et quas tempora molestiae. Illum impedit quis est nihil repellendus voluptatibus ipsum quibusdam. Neque quis quod ab qui aut. Sunt dicta quod nesciunt aut mollitia consectetur. Sequi dolores nihil molestiae consequuntur ut consequatur beatae inventore. Fuga ullam at voluptas velit qui tenetur minima fugit. Voluptas dicta deleniti facilis dolorem. Vitae nisi qui deleniti incidunt sapiente dolor. Culpa exercitationem nihil voluptas omnis. Quam excepturi aut quisquam consequatur.";
+
 export const All: Story = () => {
-	const [isDefaultModalOpen, setIsDefaultModalOpen] = useState(false);
-	const [isMiniModalOpen, setIsMiniModalOpen] = useState(false);
-	const closeBigModal = () => setIsDefaultModalOpen(false);
-	const closeMiniModal = () => setIsMiniModalOpen(false);
+	const [isDefaultDismissableModalOpen, setIsDefaultDismissableModalOpen] =
+		useState(false);
+	const [isMiniDismissableModalOpen, setIsMiniDismissableModalOpen] =
+		useState(false);
+	const [
+		isDefaultNotDismissableModalOpen,
+		setIsDefaultNotDismissableModalOpen,
+	] = useState(false);
+	const [isMiniNotDismissableModalOpen, setIsMiniNotDismissableModalOpen] =
+		useState(false);
+	const closeBigDismissableModal = () =>
+		setIsDefaultDismissableModalOpen(false);
+	const closeMiniDismissableModal = () => setIsMiniDismissableModalOpen(false);
+	const closeBigNotDismissableModal = () =>
+		setIsDefaultNotDismissableModalOpen(false);
+	const closeMiniNotDismissableModal = () =>
+		setIsMiniNotDismissableModalOpen(false);
 
 	return (
 		<StoryContainer>
-			<button type="button" onClick={() => setIsDefaultModalOpen(true)}>
-				Open default modal
+			<button
+				type="button"
+				onClick={() => setIsDefaultDismissableModalOpen(true)}
+			>
+				Open default DISMISSABLE modal
 			</button>
-			<button type="button" onClick={() => setIsMiniModalOpen(true)}>
-				Open mini modal
+			<button type="button" onClick={() => setIsMiniDismissableModalOpen(true)}>
+				Open mini DISMISSABLE modal
+			</button>
+			<button
+				type="button"
+				onClick={() => setIsDefaultNotDismissableModalOpen(true)}
+			>
+				Open default NOT DISMISSABLE modal
+			</button>
+			<button
+				type="button"
+				onClick={() => setIsMiniNotDismissableModalOpen(true)}
+			>
+				Open mini NOT DISMISSABLE modal
 			</button>
 			<Modal
-				isOpen={isMiniModalOpen}
-				closeModal={closeMiniModal}
-				title="Mini modal"
-				primaryButtonSlot={<Button onClick={closeMiniModal}>Confirm</Button>}
+				isOpen={isMiniDismissableModalOpen}
+				closeModal={closeMiniDismissableModal}
+				title="Mini dismissable modal"
+				primaryButtonSlot={
+					<Button onClick={closeMiniDismissableModal}>Confirm</Button>
+				}
 				secondaryButtonSlot={
-					<Button onClick={closeMiniModal} variant="tertiary">
+					<Button onClick={closeMiniDismissableModal} variant="tertiary">
 						Cancel
 					</Button>
 				}
 				mini
 			>
-				<P>
-					Laudantium nihil dolorem deleniti quae eos. Et ut sequi corporis.
-					Alias voluptatem laboriosam omnis sit ratione mollitia. Minus quis
-					magnam a cupiditate et. Qui voluptatibus ea nostrum repudiandae quidem
-					molestias. Et velit saepe vero aliquid id doloremque. Officia animi ut
-					natus. Sit quis neque esse ut magnam sit. Iure aspernatur quasi
-					voluptate exercitationem. Velit et provident nobis earum eligendi
-					voluptatem.
-				</P>
+				<P>{textMiniModal}</P>
 			</Modal>
 			<Modal
-				isOpen={isDefaultModalOpen}
-				closeModal={closeBigModal}
-				title="Default modal"
-				primaryButtonSlot={<Button onClick={closeBigModal}>Confirm</Button>}
+				isOpen={isDefaultDismissableModalOpen}
+				closeModal={closeBigDismissableModal}
+				title="Default dismissable modal"
+				primaryButtonSlot={
+					<Button onClick={closeBigDismissableModal}>Confirm</Button>
+				}
 				secondaryButtonSlot={
-					<Button onClick={closeBigModal} variant="tertiary">
+					<Button onClick={closeBigDismissableModal} variant="tertiary">
 						Cancel
 					</Button>
 				}
 			>
-				<P>
-					Laudantium nihil dolorem deleniti quae eos. Et ut sequi corporis.
-					Alias voluptatem laboriosam omnis sit ratione mollitia. Minus quis
-					magnam a cupiditate et. Qui voluptatibus ea nostrum repudiandae quidem
-					molestias. Et velit saepe vero aliquid id doloremque. Officia animi ut
-					natus. Sit quis neque esse ut magnam sit. Iure aspernatur quasi
-					voluptate exercitationem. Velit et provident nobis earum eligendi
-					voluptatem. Et reiciendis laudantium et nesciunt recusandae et sit
-					illum. Pariatur et quas tempora molestiae. Illum impedit quis est
-					nihil repellendus voluptatibus ipsum quibusdam. Neque quis quod ab qui
-					aut. Sunt dicta quod nesciunt aut mollitia consectetur. Sequi dolores
-					nihil molestiae consequuntur ut consequatur beatae inventore. Fuga
-					ullam at voluptas velit qui tenetur minima fugit. Voluptas dicta
-					deleniti facilis dolorem. Vitae nisi qui deleniti incidunt sapiente
-					dolor. Culpa exercitationem nihil voluptas omnis. Quam excepturi aut
-					quisquam consequatur.
-				</P>
+				<P>{textBigModal}</P>
+			</Modal>
+			<Modal
+				isOpen={isMiniNotDismissableModalOpen}
+				closeModal={closeMiniNotDismissableModal}
+				title="Mini not dismissable modal"
+				primaryButtonSlot={
+					<Button onClick={closeMiniNotDismissableModal}>Confirm</Button>
+				}
+				secondaryButtonSlot={
+					<Button onClick={closeMiniNotDismissableModal} variant="tertiary">
+						Cancel
+					</Button>
+				}
+				dismissable={false}
+				mini
+			>
+				<P>{textMiniModal}</P>
+			</Modal>
+			<Modal
+				isOpen={isDefaultNotDismissableModalOpen}
+				closeModal={closeBigNotDismissableModal}
+				title="Default not dismissable modal"
+				primaryButtonSlot={
+					<Button onClick={closeBigNotDismissableModal}>Confirm</Button>
+				}
+				secondaryButtonSlot={
+					<Button onClick={closeBigNotDismissableModal} variant="tertiary">
+						Cancel
+					</Button>
+				}
+				dismissable={false}
+			>
+				<P>{textBigModal}</P>
 			</Modal>
 		</StoryContainer>
 	);


### PR DESCRIPTION
This pull request introduces the ability to make modals dismissable or non-dismissable. It includes changes to the modal component, its styles, and the storybook examples to demonstrate the new functionality.

### Enhancements to Modal Functionality:

* Added a new `dismissable` property to the `Modal` component to control whether the modal can be dismissed by clicking the backdrop or pressing the escape key. The default value is `true`. (`src/components/modal/modal.tsx`) [[1]](diffhunk://#diff-1750b7bbce65a82bbddc6f7213b8f1cd41eec744c2d2ad386557f0d4d735e51bR24) [[2]](diffhunk://#diff-1750b7bbce65a82bbddc6f7213b8f1cd41eec744c2d2ad386557f0d4d735e51bR37)
* Updated the modal's event listeners to respect the `dismissable` property, preventing the default behavior when the modal is not dismissable. (`src/components/modal/modal.tsx`) [[1]](diffhunk://#diff-1750b7bbce65a82bbddc6f7213b8f1cd41eec744c2d2ad386557f0d4d735e51bL51-R62) [[2]](diffhunk://#diff-1750b7bbce65a82bbddc6f7213b8f1cd41eec744c2d2ad386557f0d4d735e51bL65-R79) [[3]](diffhunk://#diff-1750b7bbce65a82bbddc6f7213b8f1cd41eec744c2d2ad386557f0d4d735e51bL90-R96)

### Styling Adjustments:

* Modified the `modal.scss` to apply the `cursor: pointer` style to the backdrop only when the modal is dismissable. (`src/components/modal/modal.scss`)
* Added the `ls-dialog-dismissable` class to the modal when it is dismissable. (`src/components/modal/modal.tsx`)

### Storybook Updates:

* Updated the modal stories to include examples of both dismissable and non-dismissable modals, with corresponding buttons to open each type. (`src/components/modal/modal.stories.tsx`)