### PR TITLE
Block scroll when modal is open without shifting the content

### DIFF
--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { IconXMark } from "../../icons/icon-x-mark";
 import cn from "../../utils/cn";
+import { useLockBodyScroll } from "../../utils/use-lock-body-scroll";
 import { H3 } from "../typography";
 
 type Modal = FC<
@@ -95,6 +96,9 @@ export const Modal: Modal = ({
 		},
 		[closeModal, dismissable],
 	);
+
+	// when the modal is open, lock the body scroll, but without shifting the content due to the scrollbar
+	useLockBodyScroll(isOpen);
 
 	return (
 		// biome-ignore lint/a11y/useKeyWithClickEvents: It's fine to use click events here, as it's not a button

--- a/src/utils/use-lock-body-scroll.ts
+++ b/src/utils/use-lock-body-scroll.ts
@@ -1,0 +1,23 @@
+import { useLayoutEffect } from "react";
+
+export const useLockBodyScroll = (lock: boolean) => {
+	useLayoutEffect(() => {
+		if (!lock) return;
+
+		const originalStyle = window.getComputedStyle(document.body).overflow;
+		const scrollbarWidth =
+			window.innerWidth - document.documentElement.clientWidth;
+
+		// Apply styles to lock scroll
+		document.body.style.overflow = "hidden";
+		if (scrollbarWidth > 0) {
+			document.body.style.paddingRight = `${scrollbarWidth}px`;
+		}
+
+		// Cleanup styles on unmount or when lock is false
+		return () => {
+			document.body.style.overflow = originalStyle;
+			document.body.style.paddingRight = "";
+		};
+	}, [lock]);
+};


### PR DESCRIPTION
This pull request introduces a new hook to lock the body scroll when the modal is open and integrates it into the modal component. The most important changes include adding the `useLockBodyScroll` hook and updating the modal component to use this hook.

### New Hook Implementation:
* [`src/utils/use-lock-body-scroll.ts`](diffhunk://#diff-8ba551100d179d5b5f5b15d5e9e2099836940bf49e63c5d6e41cedcf204d8c4dR1-R23): Added the `useLockBodyScroll` hook to lock the body scroll when a specified condition is true. This hook uses `useLayoutEffect` to apply and clean up styles that lock the body scroll and handle scrollbar width adjustments.

### Integration in Modal Component:
* [`src/components/modal/modal.tsx`](diffhunk://#diff-1750b7bbce65a82bbddc6f7213b8f1cd41eec744c2d2ad386557f0d4d735e51bR13): Imported the `useLockBodyScroll` hook and utilized it within the `Modal` component to lock the body scroll when the modal is open. This ensures that the body scroll is locked without shifting the content due to the scrollbar. [[1]](diffhunk://#diff-1750b7bbce65a82bbddc6f7213b8f1cd41eec744c2d2ad386557f0d4d735e51bR13) [[2]](diffhunk://#diff-1750b7bbce65a82bbddc6f7213b8f1cd41eec744c2d2ad386557f0d4d735e51bR100-R102)