### PR TITLE
Add missing reset fn returned by form hooks

### DIFF
--- a/src/hooks/use-datepicker/use-date-picker.stories.tsx
+++ b/src/hooks/use-datepicker/use-date-picker.stories.tsx
@@ -1,5 +1,6 @@
 import type { Story } from "@ladle/react";
 import { StoryContainer } from "../../../.ladle/components";
+import { Button } from "../../components/button";
 import { useDatepicker } from "./use-datepicker";
 
 const label = "Select a date";
@@ -8,39 +9,49 @@ const defaultValue = new Date(2021, 0, 1);
 const validator = () => true;
 
 export const All: Story = () => {
-	const [asDisabled] = useDatepicker({
+	const [asDisabled, , , reset1] = useDatepicker({
 		label: label,
 		errorMessage: errorMessage,
 		disabled: true,
 		validator,
 	});
-	const [asPlaceholder] = useDatepicker({
+	const [asPlaceholder, , , reset2] = useDatepicker({
 		label: label,
 		errorMessage: errorMessage,
 		validator,
 	});
-	const [asWithDefaultValue] = useDatepicker({
+	const [asWithDefaultValue, , , reset3] = useDatepicker({
 		label: label,
 		errorMessage: errorMessage,
 		validator,
 		defaultValue,
 	});
-	const [asAsyncValidation] = useDatepicker({
+	const [asAsyncValidation, , , reset4] = useDatepicker({
 		label: label,
 		errorMessage: errorMessage,
 		validator: () =>
 			new Promise((resolve) => setTimeout(() => resolve(true), 5000)),
 		defaultValue,
 	});
-	const [asFailedValidation] = useDatepicker({
+	const [asFailedValidation, , , reset5] = useDatepicker({
 		label: label,
 		errorMessage: errorMessage,
 		validator: () => false,
 		defaultValue,
 	});
+	const resetAll = () => {
+		reset1();
+		reset2();
+		reset3();
+		reset4();
+		reset5();
+	};
 
 	return (
 		<StoryContainer>
+			<Button variant="primary" onClick={resetAll}>
+				Reset all field
+			</Button>
 			{asDisabled}
 			{asPlaceholder}
 			{asWithDefaultValue}

--- a/src/hooks/use-datepicker/use-datepicker.tsx
+++ b/src/hooks/use-datepicker/use-datepicker.tsx
@@ -49,6 +49,7 @@ export const useDatepicker: UseDatepicker = ({
 		setIsValid,
 		setIsValidating,
 		setIsErrored,
+		resetValidation,
 	} = useValidationState();
 	const [isErrorTooltipOpen, setIsErrorTooltipOpen] = useState(false);
 	const { labelId, errorMessageId } = useFormFieldIds();
@@ -107,6 +108,19 @@ export const useDatepicker: UseDatepicker = ({
 			}
 		},
 		[setIsErrored, setIsValidating, setIsValid],
+	);
+
+	const reset = useCallback<UseFormFieldReturnValue["3"]>(
+		(shouldSetDefaultValue = true) => {
+			if (shouldSetDefaultValue && defaultValue) {
+				setValue(defaultValue);
+			} else {
+				setValue(undefined);
+			}
+			resetValidation();
+			setIsErrorTooltipOpen(false);
+		},
+		[resetValidation, defaultValue],
 	);
 
 	return [
@@ -202,5 +216,6 @@ export const useDatepicker: UseDatepicker = ({
 		</RACDatePicker>,
 		value,
 		isValid,
+		reset,
 	];
 };

--- a/src/hooks/use-input-image-url/use-input-image-url.stories.tsx
+++ b/src/hooks/use-input-image-url/use-input-image-url.stories.tsx
@@ -1,5 +1,6 @@
 import type { Story } from "@ladle/react";
 import { StoryContainer } from "../../../.ladle/components";
+import { Button } from "../../components/button";
 import { useInputImageUrl } from "./use-input-image-url";
 
 const placeholder = "Placeholder";
@@ -9,13 +10,13 @@ const defaultValue = "https://placehold.co/1000x400";
 const validator = () => true;
 
 export const All: Story = () => {
-	const [component1] = useInputImageUrl({
+	const [component1, , , reset1] = useInputImageUrl({
 		label,
 		placeholder,
 		errorMessage,
 		validator,
 	});
-	const [component2] = useInputImageUrl({
+	const [component2, , , reset2] = useInputImageUrl({
 		label,
 		placeholder,
 		errorMessage,
@@ -26,30 +27,40 @@ export const All: Story = () => {
 			});
 		},
 	});
-	const [component3] = useInputImageUrl({
+	const [component3, , , reset3] = useInputImageUrl({
 		label,
 		placeholder,
 		errorMessage,
 		defaultValue,
 		validator,
 	});
-	const [component4] = useInputImageUrl({
+	const [component4, , , reset4] = useInputImageUrl({
 		label,
 		placeholder,
 		errorMessage,
 		defaultValue,
 		validator,
 	});
-	const [component5] = useInputImageUrl({
+	const [component5, , , reset5] = useInputImageUrl({
 		label,
 		placeholder,
 		errorMessage,
 		defaultValue,
 		validator: () => false,
 	});
+	const resetAll = () => {
+		reset1();
+		reset2();
+		reset3();
+		reset4();
+		reset5();
+	};
 
 	return (
 		<StoryContainer>
+			<Button variant="primary" onClick={resetAll}>
+				Reset all field
+			</Button>
 			{component1}
 			{component2}
 			{component3}

--- a/src/hooks/use-input-image-url/use-input-image-url.tsx
+++ b/src/hooks/use-input-image-url/use-input-image-url.tsx
@@ -1,6 +1,9 @@
 import { type ComponentProps, useCallback, useEffect, useState } from "react";
 import { FormFieldsLabelWithTooltip } from "../../components/internals/form-fields-label-with-tooltip";
-import type { UseFormField } from "../../types/use-form-field";
+import type {
+	UseFormField,
+	UseFormFieldReturnValue,
+} from "../../types/use-form-field";
 import cn from "../../utils/cn";
 import { useFormFieldIds } from "../../utils/use-form-field-ids";
 import { useValidationState } from "../../utils/use-validation-state";
@@ -24,6 +27,7 @@ export const useInputImageUrl: UseFormField<string> = ({
 		setIsValid,
 		setIsErrored,
 		setIsValidating,
+		resetValidation,
 	} = useValidationState();
 	const [value, setValue] = useState("");
 
@@ -78,6 +82,19 @@ export const useInputImageUrl: UseFormField<string> = ({
 		[setIsErrored, setIsValid, setIsValidating, validator],
 	);
 
+	const reset = useCallback<UseFormFieldReturnValue["3"]>(
+		(shouldSetDefaultValue = true) => {
+			if (shouldSetDefaultValue && defaultValue) {
+				setValue(defaultValue);
+			} else {
+				setValue("");
+			}
+			resetValidation();
+			setIsErrorTooltipOpen(false);
+		},
+		[resetValidation, defaultValue],
+	);
+
 	return [
 		// biome-ignore lint/correctness/useJsxKeyInIterable: it's in an iterator, yes, but is not really something you would iterate over
 		<div className={cn("ls-form-field-container", className)}>
@@ -122,5 +139,6 @@ export const useInputImageUrl: UseFormField<string> = ({
 		</div>,
 		value,
 		isValid,
+		reset,
 	];
 };

--- a/src/hooks/use-input/use-input.stories.tsx
+++ b/src/hooks/use-input/use-input.stories.tsx
@@ -1,6 +1,7 @@
 import type { Story } from "@ladle/react";
 import { z } from "zod";
 import { StoryContainer } from "../../../.ladle/components";
+import { Button } from "../../components/button";
 import { useInput } from "./use-input";
 
 const validator = (val: string) =>
@@ -12,13 +13,13 @@ const errorMessage = "Error message";
 const defaultValue = "Default value";
 
 export const All: Story = () => {
-	const [component1] = useInput({
+	const [component1, , , reset1] = useInput({
 		label,
 		placeholder,
 		errorMessage,
 		validator,
 	});
-	const [component2] = useInput({
+	const [component2, , , reset2] = useInput({
 		label,
 		placeholder,
 		errorMessage,
@@ -29,21 +30,21 @@ export const All: Story = () => {
 			});
 		},
 	});
-	const [component3] = useInput({
+	const [component3, , , reset3] = useInput({
 		label,
 		placeholder,
 		errorMessage,
 		defaultValue,
 		validator,
 	});
-	const [component4] = useInput({
+	const [component4, , , reset4] = useInput({
 		label,
 		placeholder,
 		errorMessage,
 		defaultValue,
 		validator: () => true,
 	});
-	const [component5] = useInput({
+	const [component5, , , reset5] = useInput({
 		label,
 		placeholder,
 		errorMessage,
@@ -51,8 +52,19 @@ export const All: Story = () => {
 		validator: () => false,
 	});
 
+	const resetAll = () => {
+		reset1();
+		reset2();
+		reset3();
+		reset4();
+		reset5();
+	};
+
 	return (
 		<StoryContainer>
+			<Button variant="primary" onClick={resetAll}>
+				Reset all field
+			</Button>
 			{component1}
 			{component2}
 			{component3}

--- a/src/hooks/use-input/use-input.tsx
+++ b/src/hooks/use-input/use-input.tsx
@@ -1,6 +1,9 @@
 import { type ComponentProps, useCallback, useEffect, useState } from "react";
 import { FormFieldsLabelWithTooltip } from "../../components/internals/form-fields-label-with-tooltip";
-import type { UseFormField } from "../../types/use-form-field";
+import type {
+	UseFormField,
+	UseFormFieldReturnValue,
+} from "../../types/use-form-field";
 import cn from "../../utils/cn";
 import { useFormFieldIds } from "../../utils/use-form-field-ids";
 import { useValidationState } from "../../utils/use-validation-state";
@@ -22,6 +25,7 @@ export const useInput: UseFormField<string> = ({
 		setIsValid,
 		setIsValidating,
 		setIsErrored,
+		resetValidation,
 	} = useValidationState();
 	const [isErrorTooltipOpen, setIsErrorTooltipOpen] = useState(false);
 	const { labelId, errorMessageId } = useFormFieldIds();
@@ -75,6 +79,19 @@ export const useInput: UseFormField<string> = ({
 		[setIsErrored, setIsValidating, setIsValid],
 	);
 
+	const reset = useCallback<UseFormFieldReturnValue["3"]>(
+		(shouldSetDefaultValue = true) => {
+			if (shouldSetDefaultValue && defaultValue) {
+				setValue(defaultValue);
+			} else {
+				setValue("");
+			}
+			resetValidation();
+			setIsErrorTooltipOpen(false);
+		},
+		[resetValidation, defaultValue],
+	);
+
 	return [
 		// biome-ignore lint/correctness/useJsxKeyInIterable: it's in an iterator, yes, but is not really something you would iterate over
 		<div className={cn("ls-form-field-container", className)}>
@@ -108,5 +125,6 @@ export const useInput: UseFormField<string> = ({
 		</div>,
 		value,
 		isValid,
+		reset,
 	];
 };

--- a/src/hooks/use-select/use-select.stories.tsx
+++ b/src/hooks/use-select/use-select.stories.tsx
@@ -1,5 +1,6 @@
 import type { Story } from "@ladle/react";
 import { StoryContainer } from "../../../.ladle/components";
+import { Button } from "../../components/button";
 import { useSelect } from "./use-select";
 
 const options = [
@@ -17,7 +18,7 @@ const defaultValue = options[0];
 const validator = () => true;
 
 export const All: Story = () => {
-	const [component1] = useSelect({
+	const [component1, , , reset1] = useSelect({
 		label: label,
 		placeholder: placeholder,
 		options: options,
@@ -25,14 +26,14 @@ export const All: Story = () => {
 		disabled: true,
 		validator,
 	});
-	const [component2] = useSelect({
+	const [component2, , , reset2] = useSelect({
 		label: label,
 		placeholder: placeholder,
 		options: options,
 		errorMessage: errorMessage,
 		validator,
 	});
-	const [component3] = useSelect({
+	const [component3, , , reset3] = useSelect({
 		label: label,
 		placeholder: placeholder,
 		options: options,
@@ -40,7 +41,7 @@ export const All: Story = () => {
 		validator,
 		defaultValue,
 	});
-	const [component4] = useSelect({
+	const [component4, , , reset4] = useSelect({
 		label: label,
 		placeholder: placeholder,
 		options: options,
@@ -48,7 +49,7 @@ export const All: Story = () => {
 		errorMessage,
 		defaultValue,
 	});
-	const [component5] = useSelect({
+	const [component5, , , reset5] = useSelect({
 		label: label,
 		placeholder: placeholder,
 		options: options,
@@ -57,8 +58,19 @@ export const All: Story = () => {
 		defaultValue,
 	});
 
+	const resetAll = () => {
+		reset1();
+		reset2();
+		reset3();
+		reset4();
+		reset5();
+	};
+
 	return (
 		<StoryContainer>
+			<Button variant="primary" onClick={resetAll}>
+				Reset all field
+			</Button>
 			{component1}
 			{component2}
 			{component3}

--- a/src/hooks/use-select/use-select.tsx
+++ b/src/hooks/use-select/use-select.tsx
@@ -42,6 +42,7 @@ export const useSelect: UseSelect = ({
 		setIsValid,
 		setIsValidating,
 		setIsErrored,
+		resetValidation,
 	} = useValidationState();
 	const [isErrorTooltipOpen, setIsErrorTooltipOpen] = useState(false);
 	const { labelId, errorMessageId } = useFormFieldIds();
@@ -99,6 +100,20 @@ export const useSelect: UseSelect = ({
 		}
 	}, [value, isMenuOpen, setIsErrored, hasBeenTouched]);
 
+	const reset = useCallback<UseFormFieldReturnValue["3"]>(
+		(shouldSetDefaultValue = true) => {
+			if (shouldSetDefaultValue && defaultValue) {
+				setValue(defaultValue);
+			} else {
+				setValue(undefined);
+			}
+			resetValidation();
+			setIsErrorTooltipOpen(false);
+			setHasBeenTouched(false);
+		},
+		[resetValidation, defaultValue],
+	);
+
 	return [
 		// biome-ignore lint/correctness/useJsxKeyInIterable: it's in an iterator, yes, but is not really something you would iterate over
 		<div className={cn("ls-form-field-container", className)}>
@@ -115,7 +130,9 @@ export const useSelect: UseSelect = ({
 			/>
 			<RadixSelect.Root
 				aria-labelledby={labelId}
-				value={options.find((option) => option.value === value?.value)?.value}
+				value={
+					options.find((option) => option.value === value?.value)?.value || ""
+				}
 				onValueChange={onValueChange}
 				open={isMenuOpen}
 				onOpenChange={onOpenChange}
@@ -170,5 +187,6 @@ export const useSelect: UseSelect = ({
 		</div>,
 		value,
 		isValid,
+		reset,
 	];
 };

--- a/src/hooks/use-textarea/use-textarea.stories.tsx
+++ b/src/hooks/use-textarea/use-textarea.stories.tsx
@@ -1,5 +1,6 @@
 import type { Story } from "@ladle/react";
 import { StoryContainer } from "../../../.ladle/components";
+import { Button } from "../../components/button";
 import { useTextarea } from "./use-textarea";
 
 const placeholder = "Enter your description here";
@@ -9,20 +10,20 @@ const defaultValue = "Default value";
 const validator = () => true;
 
 export const All: Story = () => {
-	const [component1] = useTextarea({
+	const [component1, , , reset1] = useTextarea({
 		label,
 		placeholder,
 		errorMessage,
 		validator,
 		disabled: true,
 	});
-	const [component2] = useTextarea({
+	const [component2, , , reset2] = useTextarea({
 		label,
 		placeholder,
 		errorMessage,
 		validator,
 	});
-	const [component3] = useTextarea({
+	const [component3, , , reset3] = useTextarea({
 		label,
 		placeholder,
 		errorMessage,
@@ -33,14 +34,14 @@ export const All: Story = () => {
 			});
 		},
 	});
-	const [component4] = useTextarea({
+	const [component4, , , reset4] = useTextarea({
 		label,
 		placeholder,
 		errorMessage,
 		defaultValue,
 		validator,
 	});
-	const [component5] = useTextarea({
+	const [component5, , , reset5] = useTextarea({
 		label,
 		placeholder,
 		errorMessage,
@@ -48,8 +49,19 @@ export const All: Story = () => {
 		validator: () => false,
 	});
 
+	const resetAll = () => {
+		reset1();
+		reset2();
+		reset3();
+		reset4();
+		reset5();
+	};
+
 	return (
 		<StoryContainer>
+			<Button variant="primary" onClick={resetAll}>
+				Reset all field
+			</Button>
 			{component1}
 			{component2}
 			{component3}

--- a/src/hooks/use-textarea/use-textarea.tsx
+++ b/src/hooks/use-textarea/use-textarea.tsx
@@ -1,6 +1,9 @@
 import { type ComponentProps, useCallback, useEffect, useState } from "react";
 import { FormFieldsLabelWithTooltip } from "../../components/internals/form-fields-label-with-tooltip";
-import type { UseFormField } from "../../types/use-form-field";
+import type {
+	UseFormField,
+	UseFormFieldReturnValue,
+} from "../../types/use-form-field";
 import cn from "../../utils/cn";
 import { useFormFieldIds } from "../../utils/use-form-field-ids";
 import { useValidationState } from "../../utils/use-validation-state";
@@ -22,6 +25,7 @@ export const useTextarea: UseFormField<string> = ({
 		setIsValid,
 		setIsValidating,
 		setIsErrored,
+		resetValidation,
 	} = useValidationState();
 	const [isErrorTooltipOpen, setIsErrorTooltipOpen] = useState(false);
 	const { labelId, errorMessageId } = useFormFieldIds();
@@ -75,6 +79,19 @@ export const useTextarea: UseFormField<string> = ({
 		[setIsErrored, setIsValidating, setIsValid],
 	);
 
+	const reset = useCallback<UseFormFieldReturnValue["3"]>(
+		(shouldSetDefaultValue = true) => {
+			if (shouldSetDefaultValue && defaultValue) {
+				setValue(defaultValue);
+			} else {
+				setValue("");
+			}
+			resetValidation();
+			setIsErrorTooltipOpen(false);
+		},
+		[resetValidation, defaultValue],
+	);
+
 	return [
 		// biome-ignore lint/correctness/useJsxKeyInIterable: it's in an iterator, yes, but is not really something you would iterate over
 		<div className={cn("ls-form-field-container", className)}>
@@ -106,5 +123,6 @@ export const useTextarea: UseFormField<string> = ({
 		</div>,
 		value,
 		isValid,
+		reset,
 	];
 };

--- a/src/types/use-form-field.ts
+++ b/src/types/use-form-field.ts
@@ -13,6 +13,7 @@ export type UseFormFieldReturnValue<T = string | undefined> = [
 	component: JSX.Element,
 	value: T,
 	isValid: boolean,
+	reset: (shouldSetDefaultValue?: boolean) => void,
 ];
 
 export type UseFormField<T = string | undefined> = (

--- a/src/utils/use-validation-state.ts
+++ b/src/utils/use-validation-state.ts
@@ -24,10 +24,15 @@ export const useValidationState = () => {
 		setState({ isValid: false, isErrored: false, isValidating: true });
 	}, []);
 
+	const resetValidation = useCallback(() => {
+		setState({ isValid: false, isErrored: false, isValidating: false });
+	}, []);
+
 	return {
 		...state,
 		setIsErrored,
 		setIsValid,
 		setIsValidating,
+		resetValidation,
 	};
 };


### PR DESCRIPTION
This pull request introduces reset functionality to multiple hooks and their corresponding story files. The main changes include adding a `reset` method to hooks and updating stories to include a button that resets all fields.

### Hook Enhancements:
* [`src/hooks/use-datepicker/use-datepicker.tsx`](diffhunk://#diff-ddc2664aa4c013eb36c801a4097158ec9809e45ab2dc55d27cb58b93cf142281R113-R125): Added a `reset` method to the `useDatepicker` hook to reset the date picker fields. [[1]](diffhunk://#diff-ddc2664aa4c013eb36c801a4097158ec9809e45ab2dc55d27cb58b93cf142281R113-R125) [[2]](diffhunk://#diff-ddc2664aa4c013eb36c801a4097158ec9809e45ab2dc55d27cb58b93cf142281R219)
* [`src/hooks/use-input-image-url/use-input-image-url.tsx`](diffhunk://#diff-1d6f4422ce61684c4e1c168b61d9efb8959b80c003b119f67999b91c8363a7dbR85-R97): Added a `reset` method to the `useInputImageUrl` hook to reset the input image URL fields. [[1]](diffhunk://#diff-1d6f4422ce61684c4e1c168b61d9efb8959b80c003b119f67999b91c8363a7dbR85-R97) [[2]](diffhunk://#diff-1d6f4422ce61684c4e1c168b61d9efb8959b80c003b119f67999b91c8363a7dbR142)
* [`src/hooks/use-input/use-input.tsx`](diffhunk://#diff-ab7cf0e644f6df503d4588b6fded1ecc17a1f69ea20f0be244be536cd45690baR82-R94): Added a `reset` method to the `useInput` hook to reset the input fields. [[1]](diffhunk://#diff-ab7cf0e644f6df503d4588b6fded1ecc17a1f69ea20f0be244be536cd45690baR82-R94) [[2]](diffhunk://#diff-ab7cf0e644f6df503d4588b6fded1ecc17a1f69ea20f0be244be536cd45690baR128)
* [`src/hooks/use-select/use-select.tsx`](diffhunk://#diff-95c118329b290386995e3e3212f3e6a6128cf0fd1b37e8dfb024ff68fde6f8bbR103-R116): Added a `reset` method to the `useSelect` hook to reset the select fields. [[1]](diffhunk://#diff-95c118329b290386995e3e3212f3e6a6128cf0fd1b37e8dfb024ff68fde6f8bbR103-R116) [[2]](diffhunk://#diff-95c118329b290386995e3e3212f3e6a6128cf0fd1b37e8dfb024ff68fde6f8bbR190)
* [`src/hooks/use-textarea/use-textarea.tsx`](diffhunk://#diff-6aca43ea2a1e64d8c0b119aabc9b57d31212d955b5af9d01f33578d0a866d128R28): Added a `reset` method to the `useTextarea` hook to reset the textarea fields.

### Story Updates:
* [`src/hooks/use-datepicker/use-date-picker.stories.tsx`](diffhunk://#diff-023b5fe5c39dd1bc6b1c5609721997968541b1a34e6f7fae5b860e23d99060bdL11-R54): Updated the story to include a button that resets all date picker fields using the new `reset` methods.
* [`src/hooks/use-input-image-url/use-input-image-url.stories.tsx`](diffhunk://#diff-07b04c45da45f98ad8dce1568ef6ee079c7b855ecef946c741dcdc7760f91d08L12-R19): Updated the story to include a button that resets all input image URL fields using the new `reset` methods. [[1]](diffhunk://#diff-07b04c45da45f98ad8dce1568ef6ee079c7b855ecef946c741dcdc7760f91d08L12-R19) [[2]](diffhunk://#diff-07b04c45da45f98ad8dce1568ef6ee079c7b855ecef946c741dcdc7760f91d08L29-R63)
* [`src/hooks/use-input/use-input.stories.tsx`](diffhunk://#diff-8555db7de026084d8cbfaeaba7d4a577f5bb28836715b819d4d6757e16c78fe9L15-R22): Updated the story to include a button that resets all input fields using the new `reset` methods. [[1]](diffhunk://#diff-8555db7de026084d8cbfaeaba7d4a577f5bb28836715b819d4d6757e16c78fe9L15-R22) [[2]](diffhunk://#diff-8555db7de026084d8cbfaeaba7d4a577f5bb28836715b819d4d6757e16c78fe9L32-R67)
* [`src/hooks/use-select/use-select.stories.tsx`](diffhunk://#diff-b694f90b018cad2d64d3abd2c3bd4c39778a3019c78127cc92eacfd883c97fd8L20-R52): Updated the story to include a button that resets all select fields using the new `reset` methods. [[1]](diffhunk://#diff-b694f90b018cad2d64d3abd2c3bd4c39778a3019c78127cc92eacfd883c97fd8L20-R52) [[2]](diffhunk://#diff-b694f90b018cad2d64d3abd2c3bd4c39778a3019c78127cc92eacfd883c97fd8R61-R73)
* [`src/hooks/use-textarea/use-textarea.stories.tsx`](diffhunk://#diff-4dd568e6f6d0763c27b1cfee267c9420e71b5aa6db2a40ffd956a8a8bded9f1aL12-R26): Updated the story to include a button that resets all textarea fields using the new `reset` methods. [[1]](diffhunk://#diff-4dd568e6f6d0763c27b1cfee267c9420e71b5aa6db2a40ffd956a8a8bded9f1aL12-R26) [[2]](diffhunk://#diff-4dd568e6f6d0763c27b1cfee267c9420e71b5aa6db2a40ffd956a8a8bded9f1aL36-R64)

These changes improve the usability of the hooks by allowing fields to be reset to their default values, enhancing the testing and demonstration capabilities in the story files.