### PR TITLE
Remove usage of use-select portal and add var to override menu z-index

### DIFF
--- a/src/hooks/use-select/select.scss
+++ b/src/hooks/use-select/select.scss
@@ -33,6 +33,7 @@
   background-color: vars.$selects-menu-background-color;
   border-radius: vars.$selects-menu-border-radius;
   box-shadow: vars.$selects-menu-shadow;
+  z-index: vars.$selects-menu-z-index;
 
   .ls-select-scroll-container {
     display: flex;

--- a/src/hooks/use-select/use-select.tsx
+++ b/src/hooks/use-select/use-select.tsx
@@ -157,32 +157,30 @@ export const useSelect: UseSelect = ({
 					/>
 					<IconChevronDown className="ls-select-icon-chevron-down" />
 				</RadixSelect.Trigger>
-				<RadixSelect.Portal>
-					<RadixSelect.Content className="ls-select-menu">
-						<RadixSelect.ScrollUpButton className="ls-select-scroll-container">
-							<IconChevronUp className="ls-select-scroll-icon" />
-						</RadixSelect.ScrollUpButton>
-						<RadixSelect.Viewport className="ls-select-menu-viewport">
-							<RadixSelect.Group>
-								{options.map(({ label, value }, i) => {
-									const key = `${i}-${label}-${value}`;
-									return (
-										<RadixSelect.Item
-											className="ls-select-menu-item"
-											value={value}
-											key={key}
-										>
-											<RadixSelect.ItemText>{label}</RadixSelect.ItemText>
-										</RadixSelect.Item>
-									);
-								})}
-							</RadixSelect.Group>
-						</RadixSelect.Viewport>
-						<RadixSelect.ScrollDownButton className="ls-select-scroll-container">
-							<IconChevronDown className="ls-select-scroll-icon" />
-						</RadixSelect.ScrollDownButton>
-					</RadixSelect.Content>
-				</RadixSelect.Portal>
+				<RadixSelect.Content className="ls-select-menu">
+					<RadixSelect.ScrollUpButton className="ls-select-scroll-container">
+						<IconChevronUp className="ls-select-scroll-icon" />
+					</RadixSelect.ScrollUpButton>
+					<RadixSelect.Viewport className="ls-select-menu-viewport">
+						<RadixSelect.Group>
+							{options.map(({ label, value }, i) => {
+								const key = `${i}-${label}-${value}`;
+								return (
+									<RadixSelect.Item
+										className="ls-select-menu-item"
+										value={value}
+										key={key}
+									>
+										<RadixSelect.ItemText>{label}</RadixSelect.ItemText>
+									</RadixSelect.Item>
+								);
+							})}
+						</RadixSelect.Group>
+					</RadixSelect.Viewport>
+					<RadixSelect.ScrollDownButton className="ls-select-scroll-container">
+						<IconChevronDown className="ls-select-scroll-icon" />
+					</RadixSelect.ScrollDownButton>
+				</RadixSelect.Content>
 			</RadixSelect.Root>
 		</div>,
 		value,

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -38,6 +38,7 @@
 // 9.2 Selects - Colors
 // 9.3 Selects - Sizes
 // 9.4 Selects - Shadows
+// 9.5 Selects - Misc
 // 10. Datepicker
 // 10.1 Datepicker - Font
 // 10.2 Datepicker - Colors
@@ -452,6 +453,9 @@ $selects-menu-items-border-radius: utils.to-rem(4) !default;
 
 // 9.4 Selects - Shadows
 $selects-menu-shadow: $shadow-4;
+
+// 9.5 Selects - Misc
+$selects-menu-z-index: 1000 !default;
 
 // 10. Datepicker
 // 10.1 Datepicker - font


### PR DESCRIPTION
This pull request includes changes to the `use-select` component and its associated styles. The changes focus on improving the styling and structure of the select menu.

Styling improvements:

* [`src/scss/variables.scss`](diffhunk://#diff-d94cf8f1c4d05542c60068c63f1576eb68620af3d8b768f00f5915b3b6b433bdR457-R459): Added a new variable `$selects-menu-z-index` under a new section `9.5 Selects - Misc` to manage the z-index of the select menu.
* [`src/hooks/use-select/select.scss`](diffhunk://#diff-a041e39c3500a68c7eea3f4382a78c70d5136cbb11d1ed02cc421b8a5a02d04eR36): Applied the new `$selects-menu-z-index` variable to the select menu's styling.

Structural changes:

* [`src/hooks/use-select/use-select.tsx`](diffhunk://#diff-95c118329b290386995e3e3212f3e6a6128cf0fd1b37e8dfb024ff68fde6f8bbL160): Removed unnecessary `RadixSelect.Portal` elements to simplify the component structure. [[1]](diffhunk://#diff-95c118329b290386995e3e3212f3e6a6128cf0fd1b37e8dfb024ff68fde6f8bbL160) [[2]](diffhunk://#diff-95c118329b290386995e3e3212f3e6a6128cf0fd1b37e8dfb024ff68fde6f8bbL185)